### PR TITLE
pypdfium2: remove invalid close calls (important!)

### DIFF
--- a/main.py
+++ b/main.py
@@ -557,14 +557,12 @@ def do_render_pymupdf(path):
 def do_render_pypdfium2(path):
     import pypdfium2
     doc = pypdfium2.PdfDocument(path)
-    for i in range(len(doc)):
-        page = doc[i]
+    for page in doc:
         bitmap = page.render(scale=150 / 72)
         img = bitmap.to_pil()
         out = f'{path}.render.pypdfium2-image-{i}.png'
         img.save(out)
         log(f'Have written to: {out}')
-    doc.close()
 
 
 # do_text_*()
@@ -599,7 +597,6 @@ def do_text_pypdfium2(path):
     doc = pypdfium2.PdfDocument(path)
     for page in doc:
         page.get_textpage().get_text_range()
-    doc.close()
 
 
 # Other


### PR DESCRIPTION
With pypdfium2, the API contract is that parent objects must not be closed before child objects are closed, i.e. order matters.

If you close the document explicitly but let pages be closed automatically on garbage collection, the document is likely to be closed before all pages are closed, which is illegal and will result in warnings.

See also https://pypdfium2.readthedocs.io/en/latest/python_api.html#memory-management.
I hope to add additional clarification to the docs soon. Seeing as this is not obvious and an easy mistake to make, I guess we should update the support model to have parents keep track of children and ensure correct order automatically.

This change removes the document close calls. Alternatively, page close calls could be added.